### PR TITLE
fix: indefinitely waiting on failed test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.6
+
+* Fix Waiting for test indefinitely if it fails
+
 ## 0.1.5
 
 * Upgraded packages versions and fixed AsyncData with list equality.

--- a/lib/src/run_zoned_wrapper.dart
+++ b/lib/src/run_zoned_wrapper.dart
@@ -1,0 +1,13 @@
+import 'dart:async';
+
+
+Future<void> runZonedGuardedWrapper(Future<void> Function() body) {
+  final completer = Completer<void>();
+  runZonedGuarded(() async {
+    await body();
+    if (!completer.isCompleted) completer.complete();
+  }, (error, stackTrace) {
+    if (!completer.isCompleted) completer.completeError(error, stackTrace);
+  });
+  return completer.future;
+}

--- a/lib/src/test_state_notifier.dart
+++ b/lib/src/test_state_notifier.dart
@@ -4,6 +4,7 @@ import 'package:meta/meta.dart';
 import 'package:riverpod/riverpod.dart'
     show Override, ProviderContainer, StateNotifier, StateNotifierProvider;
 import 'package:riverpod_test/src/diff.dart';
+import 'package:riverpod_test/src/run_zoned_wrapper.dart';
 import 'package:test/test.dart' as test;
 
 /// Creates a new `Notifier` test case with the given [description].
@@ -171,59 +172,61 @@ Future<void> stateNotifierTest<C extends StateNotifier<State>, State>({
   final unhandledErrors = <Object>[];
   var shallowEquality = false;
 
-  await runZonedGuarded(
-    () async {
-      await setUp?.call();
-      final container = ProviderContainer(overrides: overrides);
-      final states = <State>[];
-      container.listen<State>(
-        provider,
-        (previous, next) => states.add(next),
-        fireImmediately: true,
-      );
-      try {
-        final notifier = container.read(provider.notifier);
-        if (!emitBuildStates) states.clear();
-        // applies seed in the state
-        // ignore: invalid_use_of_protected_member, invalid_use_of_visible_for_testing_member
-        if (seed != null) notifier.state = seed;
-        await act?.call(notifier);
-      } catch (error) {
-        if (errors == null) rethrow;
-        unhandledErrors.add(error);
-      }
-      if (wait != null) await Future<void>.delayed(wait);
-      await Future<void>.delayed(Duration.zero);
-      container.dispose();
-      if (expect != null) {
-        final dynamic expected = expect();
-        // remove state return by seed
-        if (seed != null && states.isNotEmpty) states.remove(seed);
-        shallowEquality = '$states' == '$expected';
+  try {
+    await runZonedGuardedWrapper(
+      () async {
+        await setUp?.call();
+        final container = ProviderContainer(overrides: overrides);
+        final states = <State>[];
+        container.listen<State>(
+          provider,
+          (previous, next) => states.add(next),
+          fireImmediately: true,
+        );
         try {
-          test.expect(states, test.wrapMatcher(expected));
-        } on test.TestFailure catch (e) {
-          if (shallowEquality || expected is! List<State>) rethrow;
-          final diff = testDiff(expected: expected, actual: states);
-          final message = '${e.message}\n$diff';
-          throw test.TestFailure(message);
+          final notifier = container.read(provider.notifier);
+          if (!emitBuildStates) states.clear();
+          // applies seed in the state
+          // ignore: invalid_use_of_protected_member, invalid_use_of_visible_for_testing_member
+          if (seed != null) notifier.state = seed;
+          await act?.call(notifier);
+        } catch (error) {
+          if (errors == null) rethrow;
+          unhandledErrors.add(error);
         }
-      }
-      await verify?.call();
-      await tearDown?.call();
-    },
-    (error, stack) {
-      if (shallowEquality && error is test.TestFailure) {
-        throw test.TestFailure(
-          '''${error.message}
+        if (wait != null) await Future<void>.delayed(wait);
+        await Future<void>.delayed(Duration.zero);
+        container.dispose();
+        if (expect != null) {
+          final dynamic expected = expect();
+          // remove state return by seed
+          if (seed != null && states.isNotEmpty) states.remove(seed);
+          shallowEquality = '$states' == '$expected';
+          try {
+            test.expect(states, test.wrapMatcher(expected));
+          } on test.TestFailure catch (e) {
+            if (shallowEquality || expected is! List<State>) rethrow;
+            final diff = testDiff(expected: expected, actual: states);
+            final message = '${e.message}\n$diff';
+            throw test.TestFailure(message);
+          }
+        }
+        await verify?.call();
+        await tearDown?.call();
+      },
+    );
+  } catch (error) {
+    if (shallowEquality && error is test.TestFailure) {
+      throw test.TestFailure(
+        '''${error.message}
 WARNING: Please ensure state instances extend Equatable, override == and hashCode, or implement Comparable.
 Alternatively, consider using Matchers in the expect of the testStateNotifier rather than concrete state instances.\n''',
-        );
-      }
-      if (errors == null || !unhandledErrors.contains(error)) {
-        throw error;
-      }
-    },
-  );
+      );
+    }
+    if (errors == null || !unhandledErrors.contains(error)) {
+      throw error;
+    }
+  }
+
   if (errors != null) test.expect(unhandledErrors, test.wrapMatcher(errors()));
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: riverpod_test
 description: A testing library which makes it easy to test providers. Built to be used with the riverpod package.
-version: 0.1.5
+version: 0.1.6
 repository: https://github.com/Eronildo/riverpod_test
 homepage: https://github.com/Eronildo/riverpod_test
 topics: [test, tests, providers, riverpod, riverpod-test]

--- a/test/src/test_async_notifier_test.dart
+++ b/test/src/test_async_notifier_test.dart
@@ -101,8 +101,7 @@ void main() {
       );
 
       test('fails immediately when expectation is incorrect', () async {
-        const expectedError =
-            'Expected: [AsyncData<int>:AsyncData<int>(value: 2)]\n'
+        const expectedError = 'Expected: [AsyncData<int>:AsyncData<int>(value: 2)]\n'
             '  Actual: [AsyncData<int>:AsyncData<int>(value: 1)]\n'
             '   Which: at location [0] is '
             'AsyncData<int>:<AsyncData<int>(value: 1)> instead of '
@@ -114,75 +113,46 @@ void main() {
             '\x1B[0m\x1B[31m[-2-]\x1B[0m\x1B[32m{+1+}\x1B[0m\x1B[90m)]\x1B[0m\n'
             '\n'
             '==== end diff ====================================\n';
-        late Object actualError;
-        final completer = Completer<void>();
-        await runZonedGuarded(
-          () async {
-            unawaited(
-              asyncNotifierTest<CounterAsyncNotifier, int>(
-                provider: counterAsyncNotifierProvider(0),
-                act: (notifier) => notifier.increment(),
-                expect: () => <AsyncValue<int>>[const AsyncData<int>(2)],
-                errors: Exception.new,
-              ).then((_) => completer.complete()),
-            );
-            await completer.future;
-          },
-          (Object error, _) {
-            actualError = error;
-            if (!completer.isCompleted) completer.complete();
-          },
-        );
-        expect((actualError as TestFailure).message, expectedError);
+        try {
+          await asyncNotifierTest<CounterAsyncNotifier, int>(
+            provider: counterAsyncNotifierProvider(0),
+            act: (notifier) => notifier.increment(),
+            expect: () => <AsyncValue<int>>[const AsyncData<int>(2)],
+            errors: Exception.new,
+          );
+        } catch (e) {
+          expect((e as TestFailure).message, expectedError);
+        }
       });
 
       test(
         'fails immediately when '
         'uncaught exception occurs within notifier',
         () async {
-          late Object actualError;
-          final completer = Completer<void>();
-          await runZonedGuarded(
-            () async {
-              unawaited(
-                asyncNotifierTest<ErrorCountAsyncNotifier, int>(
-                  provider: errorCountAsyncNotifierProvider,
-                  act: (notifier) => notifier.increment(),
-                  expect: () => <AsyncValue<int>>[const AsyncData<int>(1)],
-                ).then((_) => completer.complete()),
-              );
-              await completer.future;
-            },
-            (Object error, _) {
-              actualError = error;
-              if (!completer.isCompleted) completer.complete();
-            },
-          );
-          expect(actualError, isA<ErrorCounterNotifierError>());
+          try {
+            await asyncNotifierTest<ErrorCountAsyncNotifier, int>(
+              provider: errorCountAsyncNotifierProvider,
+              act: (notifier) => notifier.increment(),
+              expect: () => <AsyncValue<int>>[const AsyncData<int>(1)],
+            );
+          } catch (e) {
+            expect(e, isA<ErrorCounterNotifierError>());
+          }
         },
       );
 
       test('fails immediately when exception occurs in act', () async {
         final exception = Exception('oops');
-        late Object actualError;
-        final completer = Completer<void>();
-        await runZonedGuarded(
-          () async {
-            unawaited(
-              asyncNotifierTest<ErrorCountAsyncNotifier, int>(
-                provider: errorCountAsyncNotifierProvider,
-                act: (_) => throw exception,
-                expect: () => [const AsyncData<int>(1)],
-              ).then((_) => completer.complete()),
-            );
-            await completer.future;
-          },
-          (Object error, _) {
-            actualError = error;
-            if (!completer.isCompleted) completer.complete();
-          },
-        );
-        expect(actualError, exception);
+
+        try {
+          await asyncNotifierTest<ErrorCountAsyncNotifier, int>(
+            provider: errorCountAsyncNotifierProvider,
+            act: (_) => throw exception,
+            expect: () => [const AsyncData<int>(1)],
+          );
+        } catch (e) {
+          expect(e, equals(exception));
+        }
       });
     });
 
@@ -377,29 +347,18 @@ void main() {
       );
 
       test('fails immediately when verify is incorrect', () async {
-        const expectedError =
-            '''Expected: <2>\n  Actual: <1>\nUnexpected number of calls\n''';
-        late Object actualError;
-        final completer = Completer<void>();
-        await runZonedGuarded(
-          () async {
-            unawaited(
-              asyncNotifierTest<SideEffectAsyncNotifier, int>(
-                provider: sideEffectAsyncNotifierProvider(1),
-                overrides: overrides,
-                act: (notifier) => notifier.increment(),
-                verify: (_) => verify(repository.sideEffect).called(2),
-                tearDown: overrides.clear,
-              ).then((_) => completer.complete()),
-            );
-            await completer.future;
-          },
-          (Object error, _) {
-            actualError = error;
-            if (!completer.isCompleted) completer.complete();
-          },
-        );
-        expect((actualError as TestFailure).message, expectedError);
+        const expectedError = '''Expected: <2>\n  Actual: <1>\nUnexpected number of calls\n''';
+        try {
+          await asyncNotifierTest<SideEffectAsyncNotifier, int>(
+            provider: sideEffectAsyncNotifierProvider(1),
+            overrides: overrides,
+            act: (notifier) => notifier.increment(),
+            verify: (_) => verify(repository.sideEffect).called(2),
+            tearDown: overrides.clear,
+          );
+        } catch (e) {
+          expect((e as TestFailure).message, expectedError);
+        }
       });
 
       test('shows equality warning when strings are identical', () async {
@@ -409,27 +368,18 @@ void main() {
    Which: at location [0] is AsyncData<ComplexState>:<AsyncData<ComplexState>(value: Instance of 'ComplexStateA')> instead of AsyncData<ComplexState>:<AsyncData<ComplexState>(value: Instance of 'ComplexStateA')>\n
 WARNING: Please ensure state instances extend Equatable, override == and hashCode, or implement Comparable.
 Alternatively, consider using Matchers in the expect of the testAsyncNotifier rather than concrete state instances.\n''';
-        late Object actualError;
-        final completer = Completer<void>();
-        await runZonedGuarded(
-          () async {
-            unawaited(
-              asyncNotifierTest<ComplexAsyncNotifier, ComplexState>(
-                provider: complexAsyncNotifierProvider,
-                act: (notifier) => notifier.setComplexStateA(),
-                expect: () => <AsyncValue<ComplexState>>[
-                  AsyncData(ComplexStateA()),
-                ],
-              ).then((_) => completer.complete()),
-            );
-            await completer.future;
-          },
-          (Object error, _) {
-            actualError = error;
-            completer.complete();
-          },
-        );
-        expect((actualError as TestFailure).message, expectedError);
+
+        try {
+          await asyncNotifierTest<ComplexAsyncNotifier, ComplexState>(
+            provider: complexAsyncNotifierProvider,
+            act: (notifier) => notifier.setComplexStateA(),
+            expect: () => <AsyncValue<ComplexState>>[
+              AsyncData(ComplexStateA()),
+            ],
+          );
+        } catch (e) {
+          expect((e as TestFailure).message, expectedError);
+        }
       });
     });
   });

--- a/test/src/test_notifier_test.dart
+++ b/test/src/test_notifier_test.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:mocktail/mocktail.dart';
 import 'package:riverpod/riverpod.dart';
 import 'package:riverpod_test/riverpod_test.dart';

--- a/test/src/test_notifier_test.dart
+++ b/test/src/test_notifier_test.dart
@@ -53,75 +53,46 @@ void main() {
             '\x1B[90m[\x1B[0m\x1B[31m[-2-]\x1B[0m\x1B[32m{+1+}\x1B[0m\x1B[90m]\x1B[0m\n'
             '\n'
             '==== end diff ====================================\n';
-        late Object actualError;
-        final completer = Completer<void>();
-        await runZonedGuarded(
-          () async {
-            unawaited(
-              notifierTest<CounterNotifier, int>(
-                provider: counterNotifierProvider,
-                act: (notifier) => notifier.increment(),
-                expect: () => <int>[2],
-                errors: Exception.new,
-              ).then((_) => completer.complete()),
-            );
-            await completer.future;
-          },
-          (Object error, _) {
-            actualError = error;
-            if (!completer.isCompleted) completer.complete();
-          },
-        );
-        expect((actualError as TestFailure).message, expectedError);
+        try {
+          await notifierTest<CounterNotifier, int>(
+            provider: counterNotifierProvider,
+            act: (notifier) => notifier.increment(),
+            expect: () => <int>[2],
+            errors: Exception.new,
+          );
+        } catch (e) {
+          expect((e as TestFailure).message, expectedError);
+        }
       });
 
       test(
         'fails immediately when '
         'uncaught exception occurs within notifier',
         () async {
-          late Object actualError;
-          final completer = Completer<void>();
-          await runZonedGuarded(
-            () async {
-              unawaited(
-                notifierTest<ErrorCounterNotifier, int>(
-                  provider: errorNotifierProvider,
-                  act: (notifier) => notifier.increment(),
-                  expect: () => <int>[1],
-                ).then((_) => completer.complete()),
-              );
-              await completer.future;
-            },
-            (Object error, _) {
-              actualError = error;
-              if (!completer.isCompleted) completer.complete();
-            },
-          );
-          expect(actualError, isA<CounterNotifierError>());
+          try {
+            await notifierTest<ErrorCounterNotifier, int>(
+              provider: errorNotifierProvider,
+              act: (notifier) => notifier.increment(),
+              expect: () => <int>[1],
+            );
+          } catch (e) {
+            expect(e, isA<CounterNotifierError>());
+          }
         },
       );
 
       test('fails immediately when exception occurs in act', () async {
         final exception = Exception('oops');
-        late Object actualError;
-        final completer = Completer<void>();
-        await runZonedGuarded(
-          () async {
-            unawaited(
-              notifierTest<ErrorCounterNotifier, int>(
-                provider: errorNotifierProvider,
-                act: (_) => throw exception,
-                expect: () => [1],
-              ).then((_) => completer.complete()),
-            );
-            await completer.future;
-          },
-          (Object error, _) {
-            actualError = error;
-            if (!completer.isCompleted) completer.complete();
-          },
-        );
-        expect(actualError, exception);
+
+        try {
+          await notifierTest<ErrorCounterNotifier, int>(
+            provider: errorNotifierProvider,
+            act: (_) => throw exception,
+            expect: () => [1],
+          );
+        } catch (e) {
+          expect(e, equals(exception));
+        }
       });
     });
 
@@ -253,29 +224,18 @@ void main() {
       );
 
       test('fails immediately when verify is incorrect', () async {
-        const expectedError =
-            '''Expected: <2>\n  Actual: <1>\nUnexpected number of calls\n''';
-        late Object actualError;
-        final completer = Completer<void>();
-        await runZonedGuarded(
-          () async {
-            unawaited(
-              notifierTest<SideEffectCounterNotifier, int>(
-                provider: sideEffectCounterNotifierProvider,
-                overrides: overrides,
-                act: (notifier) => notifier.increment(),
-                verify: (_) => verify(repository.sideEffect).called(2),
-                tearDown: overrides.clear,
-              ).then((_) => completer.complete()),
-            );
-            await completer.future;
-          },
-          (Object error, _) {
-            actualError = error;
-            if (!completer.isCompleted) completer.complete();
-          },
-        );
-        expect((actualError as TestFailure).message, expectedError);
+        const expectedError = '''Expected: <2>\n  Actual: <1>\nUnexpected number of calls\n''';
+        try {
+          await notifierTest<SideEffectCounterNotifier, int>(
+            provider: sideEffectCounterNotifierProvider,
+            overrides: overrides,
+            act: (notifier) => notifier.increment(),
+            verify: (_) => verify(repository.sideEffect).called(2),
+            tearDown: overrides.clear,
+          );
+        } catch (e) {
+          expect((e as TestFailure).message, expectedError);
+        }
       });
 
       test('shows equality warning when strings are identical', () async {
@@ -284,25 +244,15 @@ void main() {
    Which: at location [0] is <Instance of 'ComplexStateA'> instead of <Instance of 'ComplexStateA'>\n
 WARNING: Please ensure state instances extend Equatable, override == and hashCode, or implement Comparable.
 Alternatively, consider using Matchers in the expect of the testNotifier rather than concrete state instances.\n''';
-        late Object actualError;
-        final completer = Completer<void>();
-        await runZonedGuarded(
-          () async {
-            unawaited(
-              notifierTest<ComplexNotifier, ComplexState>(
-                provider: complexNotifierProvider,
-                act: (notifier) => notifier.setComplexStateA(),
-                expect: () => <ComplexState>[ComplexStateA()],
-              ).then((_) => completer.complete()),
-            );
-            await completer.future;
-          },
-          (Object error, _) {
-            actualError = error;
-            completer.complete();
-          },
-        );
-        expect((actualError as TestFailure).message, expectedError);
+        try {
+          await notifierTest<ComplexNotifier, ComplexState>(
+            provider: complexNotifierProvider,
+            act: (notifier) => notifier.setComplexStateA(),
+            expect: () => <ComplexState>[ComplexStateA()],
+          );
+        } catch (e) {
+          expect((e as TestFailure).message, expectedError);
+        }
       });
     });
 

--- a/test/src/test_provider_test.dart
+++ b/test/src/test_provider_test.dart
@@ -34,25 +34,15 @@ void main() {
             '\x1B[90m[\x1B[0m\x1B[31m[-1-]\x1B[0m\x1B[32m{+0+}\x1B[0m\x1B[90m]\x1B[0m\n'
             '\n'
             '==== end diff ====================================\n';
-        late Object actualError;
-        final completer = Completer<void>();
-        await runZonedGuarded(
-          () async {
-            unawaited(
-              providerTest<int>(
-                provider: counterProvider,
-                expect: () => <int>[1],
-                errors: Exception.new,
-              ).then((_) => completer.complete()),
-            );
-            await completer.future;
-          },
-          (Object error, _) {
-            actualError = error;
-            if (!completer.isCompleted) completer.complete();
-          },
-        );
-        expect((actualError as TestFailure).message, expectedError);
+        try {
+          await providerTest<int>(
+            provider: counterProvider,
+            expect: () => <int>[1],
+            errors: Exception.new,
+          );
+        } catch (e) {
+          expect((e as TestFailure).message, expectedError);
+        }
       });
     });
 
@@ -71,8 +61,7 @@ void main() {
         'expect [AsyncLoading(), AsyncData(1)]',
         provider: futureProvider,
         overrides: overrides,
-        setUp: () =>
-            when(mockRepository.fetchCounter).thenAnswer((_) async => 1),
+        setUp: () => when(mockRepository.fetchCounter).thenAnswer((_) async => 1),
         expect: () => <AsyncValue<int>>[
           const AsyncLoading(),
           const AsyncData(1),
@@ -84,8 +73,7 @@ void main() {
         'expect [AsyncLoading(), AsyncData([])]',
         provider: futureListProvider,
         overrides: overrides,
-        setUp: () =>
-            when(mockRepository.fetchCounterList).thenAnswer((_) async => []),
+        setUp: () => when(mockRepository.fetchCounterList).thenAnswer((_) async => []),
         expect: () => <AsyncValue<List<int>>>[
           const AsyncLoading(),
           const AsyncData([]),
@@ -104,28 +92,17 @@ void main() {
       );
 
       test('fails immediately when verify is incorrect', () async {
-        const expectedError =
-            '''Expected: <2>\n  Actual: <1>\nUnexpected number of calls\n''';
-        late Object actualError;
-        final completer = Completer<void>();
-        await runZonedGuarded(
-          () async {
-            unawaited(
-              providerTest<AsyncValue<int>>(
-                provider: futureProvider,
-                overrides: overrides,
-                verify: () => verify(mockRepository.fetchCounter).called(2),
-                tearDown: overrides.clear,
-              ).then((_) => completer.complete()),
-            );
-            await completer.future;
-          },
-          (Object error, _) {
-            actualError = error;
-            if (!completer.isCompleted) completer.complete();
-          },
-        );
-        expect((actualError as TestFailure).message, expectedError);
+        const expectedError = '''Expected: <2>\n  Actual: <1>\nUnexpected number of calls\n''';
+        try {
+          await providerTest<AsyncValue<int>>(
+            provider: futureProvider,
+            overrides: overrides,
+            verify: () => verify(mockRepository.fetchCounter).called(2),
+            tearDown: overrides.clear,
+          );
+        } catch (e) {
+          expect((e as TestFailure).message, expectedError);
+        }
       });
 
       test('shows equality warning when strings are identical', () async {
@@ -134,24 +111,14 @@ void main() {
    Which: at location [0] is <Instance of 'CounterDataSource'> instead of <Instance of 'CounterDataSource'>\n
 WARNING: Please ensure state instances extend Equatable, override == and hashCode, or implement Comparable.
 Alternatively, consider using Matchers in the expect of the testProvider rather than concrete state instances.\n''';
-        late Object actualError;
-        final completer = Completer<void>();
-        await runZonedGuarded(
-          () async {
-            unawaited(
-              providerTest<CounterDataSource>(
-                provider: counterDataSourceProvider,
-                expect: () => <CounterDataSource>[CounterDataSource()],
-              ).then((_) => completer.complete()),
-            );
-            await completer.future;
-          },
-          (Object error, _) {
-            actualError = error;
-            completer.complete();
-          },
-        );
-        expect((actualError as TestFailure).message, expectedError);
+        try {
+          await providerTest<CounterDataSource>(
+            provider: counterDataSourceProvider,
+            expect: () => <CounterDataSource>[CounterDataSource()],
+          );
+        } catch (e) {
+          expect((e as TestFailure).message, expectedError);
+        }
       });
     });
 

--- a/test/src/test_provider_test.dart
+++ b/test/src/test_provider_test.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:mocktail/mocktail.dart';
 import 'package:riverpod/riverpod.dart';
 import 'package:riverpod_test/riverpod_test.dart';

--- a/test/src/test_result_provider_test.dart
+++ b/test/src/test_result_provider_test.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:mocktail/mocktail.dart';
 import 'package:riverpod/riverpod.dart';
 import 'package:riverpod_test/riverpod_test.dart';

--- a/test/src/test_state_notifier_test.dart
+++ b/test/src/test_state_notifier_test.dart
@@ -39,26 +39,17 @@ void main() {
             '\x1B[90m[\x1B[0m\x1B[31m[-2-]\x1B[0m\x1B[32m{+1+}\x1B[0m\x1B[90m]\x1B[0m\n'
             '\n'
             '==== end diff ====================================\n';
-        late Object actualError;
-        final completer = Completer<void>();
-        await runZonedGuarded(
-          () async {
-            unawaited(
-              stateNotifierTest<CounterStateNotifier, int>(
-                provider: counterStateNotifierProvider,
-                act: (notifier) => notifier.increment(),
-                expect: () => <int>[2],
-                errors: Exception.new,
-              ).then((_) => completer.complete()),
-            );
-            await completer.future;
-          },
-          (Object error, _) {
-            actualError = error;
-            if (!completer.isCompleted) completer.complete();
-          },
-        );
-        expect((actualError as TestFailure).message, expectedError);
+
+        try {
+          await stateNotifierTest<CounterStateNotifier, int>(
+            provider: counterStateNotifierProvider,
+            act: (notifier) => notifier.increment(),
+            expect: () => <int>[2],
+            errors: Exception.new,
+          );
+        } catch (e) {
+          expect((e as TestFailure).message, equals(expectedError));
+        }
       });
     });
 
@@ -119,29 +110,19 @@ void main() {
       );
 
       test('fails immediately when verify is incorrect', () async {
-        const expectedError =
-            '''Expected: <2>\n  Actual: <1>\nUnexpected number of calls\n''';
-        late Object actualError;
-        final completer = Completer<void>();
-        await runZonedGuarded(
-          () async {
-            unawaited(
-              stateNotifierTest<SideEffectStateNotifier, int>(
-                provider: sideEffectStateNotifierProvider,
-                overrides: overrides,
-                act: (notifier) => notifier.increment(),
-                verify: () => verify(repository.sideEffect).called(2),
-                tearDown: overrides.clear,
-              ).then((_) => completer.complete()),
-            );
-            await completer.future;
-          },
-          (Object error, _) {
-            actualError = error;
-            if (!completer.isCompleted) completer.complete();
-          },
-        );
-        expect((actualError as TestFailure).message, expectedError);
+        const expectedError = '''Expected: <2>\n  Actual: <1>\nUnexpected number of calls\n''';
+
+        try {
+          await stateNotifierTest<SideEffectStateNotifier, int>(
+            provider: sideEffectStateNotifierProvider,
+            overrides: overrides,
+            act: (notifier) => notifier.increment(),
+            verify: () => verify(repository.sideEffect).called(2),
+            tearDown: overrides.clear,
+          );
+        } catch (error) {
+          expect((error as TestFailure).message, expectedError);
+        }
       });
 
       test('shows equality warning when strings are identical', () async {
@@ -150,25 +131,15 @@ void main() {
    Which: at location [0] is <Instance of 'ComplexStateA'> instead of <Instance of 'ComplexStateA'>\n
 WARNING: Please ensure state instances extend Equatable, override == and hashCode, or implement Comparable.
 Alternatively, consider using Matchers in the expect of the testStateNotifier rather than concrete state instances.\n''';
-        late Object actualError;
-        final completer = Completer<void>();
-        await runZonedGuarded(
-          () async {
-            unawaited(
-              stateNotifierTest<ComplexStateNotifier, ComplexState>(
-                provider: complexStateNotifierProvider,
-                act: (notifier) => notifier.setComplexStateA(),
-                expect: () => <ComplexState>[ComplexStateA()],
-              ).then((_) => completer.complete()),
-            );
-            await completer.future;
-          },
-          (Object error, _) {
-            actualError = error;
-            completer.complete();
-          },
-        );
-        expect((actualError as TestFailure).message, expectedError);
+        try {
+          await stateNotifierTest<ComplexStateNotifier, ComplexState>(
+            provider: complexStateNotifierProvider,
+            act: (notifier) => notifier.setComplexStateA(),
+            expect: () => <ComplexState>[ComplexStateA()],
+          );
+        } catch (error) {
+          expect((error as TestFailure).message, expectedError);
+        }
       });
     });
   });

--- a/test/src/test_state_notifier_test.dart
+++ b/test/src/test_state_notifier_test.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:mocktail/mocktail.dart';
 import 'package:riverpod/riverpod.dart';
 import 'package:riverpod_test/riverpod_test.dart';


### PR DESCRIPTION
I encountered problem with StateNotifier testing using this package. When I started test, in which `expect` section failed, test indefinitely runs.

Just run this code in DartPad. Act callback created in different zone and exception is not handled in tests runZonedGuarded

```
import 'dart:async';

Future<void> main() async {
  try {
    try {
      final act = (PlainClass testObject) async {
        await testObject.value;
      };

      await runZonedGuarded(
        () async {
          await act(PlainClass());
        },
        (error, stackTrace) {
          throw error;
        },
      );
      
      print('end');
    } catch (e) {
      print('unexpected behavior');
    }
  } catch (e) {
    print('normal');
  }
}

class PlainClass {
  final value = Future.error(
    Exception('test exception'),
  );
}
```
