### PR TITLE
Include stackTrace when rethrowing

### DIFF
--- a/lib/src/test_provider.dart
+++ b/lib/src/test_provider.dart
@@ -181,16 +181,16 @@ Future<void> providerTest<State>({
         await tearDown?.call();
       },
     );
-  } catch (error) {
+  } catch (error, stackTrace) {
     if (shallowEquality && error is test.TestFailure) {
-      throw test.TestFailure(
+      Error.throwWithStackTrace(test.TestFailure(
         '''${error.message}
 WARNING: Please ensure state instances extend Equatable, override == and hashCode, or implement Comparable.
 Alternatively, consider using Matchers in the expect of the testProvider rather than concrete state instances.\n''',
-      );
+      ), stackTrace);
     }
     if (errors == null || !unhandledErrors.contains(error)) {
-      throw error;
+      rethrow;
     }
   }
 


### PR DESCRIPTION
My subject code was throwing an exception my test ran into and I notice the stack trace was swallowed:

Here's what got thrown:
```dart
package:riverpod_test/src/test_result_provider.dart 173:7  resultProviderTest

UnimplementedError
```

If we rethrow, we get this:
```dart
package:riverpod/src/framework/container.dart 241:21                                                  ProviderContainer.read
package:riverpod_test/src/test_result_provider.dart 137:34                                            resultProviderTest.<fn>
package:riverpod_test/src/run_zoned_wrapper.dart 6:5                                                  runZonedGuardedWrapper.<fn>
package:features/src/common/list_segmentation_v2/model/filter_descriptor.dart 36:5                    FilterTypeExt.filterDescriptorRoot
package:features/src/common/list_segmentation_v2/provider/data/filter_descriptor_provider.dart 13:44  filterDescriptor
package:riverpod/src/framework/container.dart 241:21                                                  ProviderContainer.read
package:riverpod_test/src/test_result_provider.dart 137:34                                            resultProviderTest.<fn>
dart:async                                                                                            _CustomZone.registerUnaryCallback
package:riverpod_test/src/test_result_provider.dart 135:9                                             resultProviderTest.<fn>
package:riverpod_test/src/run_zoned_wrapper.dart 6:15                                                 runZonedGuardedWrapper.<fn>
dart:async                                                                                            runZonedGuarded
package:riverpod_test/src/run_zoned_wrapper.dart 5:3                                                  runZonedGuardedWrapper
package:riverpod_test/src/test_result_provider.dart 133:11                                            resultProviderTest
package:riverpod_test/src/test_result_provider.dart 104:11                                            testResultProvider.<fn>
===== asynchronous gap ===========================
dart:async                                                                                            _Completer.completeError
package:riverpod_test/src/run_zoned_wrapper.dart 9:43                                                 runZonedGuardedWrapper.<fn>
===== asynchronous gap ===========================
dart:async                                                                                            _CustomZone.registerBinaryCallback
package:riverpod_test/src/run_zoned_wrapper.dart 6:5                                                  runZonedGuardedWrapper.<fn>
dart:async                                                                                            runZonedGuarded
package:riverpod_test/src/run_zoned_wrapper.dart 5:3                                                  runZonedGuardedWrapper
package:riverpod_test/src/test_result_provider.dart 133:11                                            resultProviderTest
package:riverpod_test/src/test_result_provider.dart 104:11                                            testResultProvider.<fn>

UnimplementedError
```
I didn't run into the other error scenario that throws test.TestFailure, but I also changed to Error.throwWithStackTrace while I was there

This pattern probably lies elsewhere, feel free to disregard this PR and address elsewhere – just wanted to bring this to your attention

This package seems cool (just started using it yesterday). Thanks for publishing this.
